### PR TITLE
Bump Dockerfile and dependencies to latest as of 2022-10-29

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -21,7 +21,7 @@ echo "🧱 Building image: ${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}"
 
 export DOCKER_BUILDKIT=1
 
-docker build --tag "${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}" --file "${FOLDER}/Dockerfile" .
+docker build --tag "${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}" --file "${FOLDER}/Dockerfile" server
 
 echo "Starting tagging & publishing of image: ${DOCKER_IMAGE_TAG}:${IMAGE_VERSION_TAG}"
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,11 +1,11 @@
-FROM tensorflow/tensorflow:2.2.3-py3-jupyter
+FROM tensorflow/tensorflow:2.10.0-jupyter
 
 RUN pip3 install keras==2.10.0
 
-RUN pip3 install scikit-learn==0.24.2 scikit-image==0.17.2
+RUN pip3 install scikit-learn==1.1.3 scikit-image==0.19.3
 
 RUN pip3 uninstall -y enum34
-RUN pip3 install specklepy==2.6.7 cherrypy==18.8.0
+RUN pip3 install specklepy==2.9.0 cherrypy==18.8.0
 RUN pip3 install cherrypy-cors==1.6
 
 COPY . /app

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,7 +6,7 @@ RUN gdown https://drive.google.com/uc?id=19dfvGvDfCRYaqxVKypp1fRHwK7XtSjVu
 
 FROM tensorflow/tensorflow:2.10.0-jupyter
 
-RUN pip3 install keras==2.2.4
+RUN pip3 install keras==2.10.0
 
 RUN pip3 install scikit-learn==1.1.3 scikit-image==0.19.3
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,3 +1,9 @@
+FROM python:3.9.15-buster AS model-download
+
+RUN pip3 install gdown
+
+RUN gdown https://drive.google.com/uc?id=19dfvGvDfCRYaqxVKypp1fRHwK7XtSjVu
+
 FROM tensorflow/tensorflow:2.10.0-jupyter
 
 RUN pip3 install keras==2.2.4
@@ -8,6 +14,7 @@ RUN pip3 uninstall -y enum34
 RUN pip3 install specklepy==2.9.0 cherrypy==18.8.0
 RUN pip3 install cherrypy-cors==1.6
 
+COPY --from=model-download nyu.h5 /app/nyu.h5
 COPY . /app
 
 WORKDIR /app

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,11 +2,11 @@ FROM tensorflow/tensorflow:2.2.3-py3-jupyter
 
 RUN pip3 install keras==2.10.0
 
-RUN pip3 install scikit-learn scikit-image
+RUN pip3 install scikit-learn==0.24.2 scikit-image==0.17.2
 
 RUN pip3 uninstall -y enum34
-RUN pip3 install specklepy cherrypy
-RUN pip3 install cherrypy-cors
+RUN pip3 install specklepy==2.6.7 cherrypy==18.8.0
+RUN pip3 install cherrypy-cors==1.6
 
 COPY . /app
 

--- a/server/layers.py
+++ b/server/layers.py
@@ -1,4 +1,4 @@
-from keras.engine.topology import Layer, InputSpec
+from tensorflow.keras.layers import Layer, InputSpec
 import keras.utils.conv_utils as conv_utils
 import tensorflow as tf
 import keras.backend as K


### PR DESCRIPTION
We should stay on top of version changes to ensure that we're using an appropriately security-patched version.