### PR TITLE
chore(deps): use bullseye debian release (current stable)

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.16-buster AS model-download
+FROM python:3.9.16-bullseye AS model-download
 
 RUN pip3 install gdown
 


### PR DESCRIPTION
bullseye is the current stable debian distribution, buster is superseded by bullseye